### PR TITLE
添加语法突出显示并改进 docsify 的代码块样式

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -7,6 +7,25 @@
   <meta name="description" content="Description">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, minimum-scale=1.0">
   <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/docsify@4/lib/themes/vue.css">
+  <style type="text/css">	
+	.markdown-section pre[data-lang] {
+		overflow: auto !important;
+	}
+	
+	.markdown-section pre[data-lang] code {
+		overflow: visible;
+	}
+
+	.line-numbers .line-numbers-rows {
+		border-right : 0px solid white;
+		/* Fix paddings to align with code.*/
+		padding: 5px; /* Same as code block */
+	}
+	
+	.markdown-section pre > code {
+		padding: 5px;
+	}
+  </style>
 </head>
 <body>
   <div id="app"></div>
@@ -16,7 +35,25 @@
       repo: '',
       loadSidebar: true,
       subMaxLevel: 3,
-      coverpage: true
+      coverpage: true,
+      markdown: {
+            renderer:{
+				code: function(code, lang) {
+				    if(lang =='html'){
+					  code = code.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;").replace(/'/g, "&#039;");
+					}
+					return ('<pre data-lang="'+lang+'"><code class="line-numbers language-'+lang+'">'+code+'</code></pre>')
+				}
+			}	  
+	 },
+	 plugins: [
+		  function (hook, vm) {
+			  hook.doneEach(function (html) {                
+				Prism.highlightAll();
+			  })
+		  }
+	  ]
+
     }
   </script>
   <!-- Docsify v4 -->


### PR DESCRIPTION
- 添加自定义 CSS 样式以更好地处理代码块溢出和行号对齐
- 配置 docsify markdown 渲染器以正确转义 HTML 内容并添加特定于语言的类
- 集成Prism.js插件以自动突出显示代码块的语法
- 修复行号的填充和边框样式，使其与代码内容保持一致