### PR TITLE
在文档中为代码块启用行号

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -17,9 +17,8 @@
 	}
 
 	.line-numbers .line-numbers-rows {
-		border-right : 0px solid white;
-		/* Fix paddings to align with code.*/
-		padding: 5px; /* Same as code block */
+		border-right: 1px solid #ccc;
+		padding: 5px;
 	}
 	
 	.markdown-section pre > code {
@@ -59,5 +58,7 @@
   <!-- Docsify v4 -->
   <script src="//cdn.jsdelivr.net/npm/docsify@4"></script>
   <script src="//cdn.jsdelivr.net/npm/prismjs@1.30.0/components/prism-ini.min.js"></script>
+  <script src="//cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/line-numbers/prism-line-numbers.min.js"></script>
+  <link rel="stylesheet" href="//cdn.jsdelivr.net/npm/prismjs@1.30.0/plugins/line-numbers/prism-line-numbers.css">
 </body>
 </html>


### PR DESCRIPTION
- 添加Prism.js行号插件脚本和样式
- 更新 CSS 以正确设置带有边框和填充的行号样式
- 包括行号功能所需的 CDN 链接